### PR TITLE
Fixed scaling maximum problem, reset scaling after EE switch

### DIFF
--- a/temoto/include/temoto/start_teleop.h
+++ b/temoto/include/temoto/start_teleop.h
@@ -139,6 +139,9 @@ private:
   /// Scaling factor
   double pos_scale_;
   double rot_scale_;
+
+  // Scaling factor maxs
+  double pos_scale_max_, rot_scale_max_;
   
   /// Amplification of input hand motion. (Scaling factor scales the amplification.)
   int8_t AMP_HAND_MOTION_;

--- a/temoto/src/start_teleop.cpp
+++ b/temoto/src/start_teleop.cpp
@@ -510,8 +510,10 @@ void Teleoperator::processPowermate(griffin_powermate::PowermateEvent powermate)
     rot_scale_ = rot_scale_ + step;
 
     // cap the scales
-    if (pos_scale_ > pos_scale_max_) pos_scale_ = pos_scale_max_;
-    if (rot_scale_ > rot_scale_max_) rot_scale_ = rot_scale_max_;
+    if (pos_scale_ > pos_scale_max_)
+      pos_scale_ = pos_scale_max_;
+    if (rot_scale_ > rot_scale_max_)
+      rot_scale_ = rot_scale_max_;
 
     return;
   } // else

--- a/temoto/src/start_teleop.cpp
+++ b/temoto/src/start_teleop.cpp
@@ -510,8 +510,8 @@ void Teleoperator::processPowermate(griffin_powermate::PowermateEvent powermate)
     rot_scale_ = rot_scale_ + step;
 
     // cap the scales
-    if (pos_scale_ > 1.) pos_scale_ = 1.;
-    if (rot_scale_ > 0.01) rot_scale_ = 0.01;
+    if (pos_scale_ > pos_scale_max_) pos_scale_ = pos_scale_max_;
+    if (rot_scale_ > rot_scale_max_) rot_scale_ = rot_scale_max_;
 
     return;
   } // else
@@ -769,6 +769,10 @@ void Teleoperator::setScale()
       rot_scale_ = get_ros_params::getDoubleParam("temoto/motion_scales/pt_to_pt/manip_rot_scale", n_);
     }
   }
+
+  // Set the max scaling factors as multiples of the defaults
+  pos_scale_max_ = 5*pos_scale_;
+  rot_scale_max_ = 5*rot_scale_;
 }
 
 // Switch to the next available EE
@@ -788,6 +792,9 @@ void Teleoperator::switchEE()
 
   // Reset the hand marker to be at the EE
   reset_ee_graphic_pose_ = true;
+
+  // Reset the scale when switching EE's
+  setScale();
 }
 
 // Calculate a transform between 2 frames


### PR DESCRIPTION
I noticed after messing with the Griffin, my EE would rotate very slowly no mater what. The limits were hard coded in (in function setScale) and were below my limits. I updated to set the max scaling limits every time the scale is changed. The maxes are 5 times the default - so this won't happen again.

I also went ahead and called setScale from EEswitch, so that the scaling is reset when you switch EE's.

I am trying to understand Git better, so I made this a branch instead of just committing :) I am prepping my Git skills for when we have to start working with UF and FIU to put all the code together